### PR TITLE
add project to tag by name

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -19,9 +19,11 @@ app.configure ()->
 
 app.get  '/user/:user_id/tag', controller.getUserTags
 app.post '/user/:user_id/tag', controller.createTag
+app.put '/user/:user_id/tag', controller.updateTagUserIds
 app.post '/user/:user_id/tag/:tag_id/rename', controller.renameTag
 app.del  '/user/:user_id/tag/:tag_id', controller.deleteTag
 app.post '/user/:user_id/tag/:tag_id/project/:project_id', controller.addProjectToTag
+app.post '/user/:user_id/tag/project/:project_id', controller.addProjectToTagName
 app.del  '/user/:user_id/tag/:tag_id/project/:project_id', controller.removeProjectFromTag
 app.del  '/user/:user_id/project/:project_id', controller.removeProjectFromAllTags
 

--- a/app/coffee/Repositories/Tags.coffee
+++ b/app/coffee/Repositories/Tags.coffee
@@ -15,6 +15,13 @@ module.exports = Tags =
 	createTag: (user_id, name, callback = (err, tag) ->) ->
 		db.tags.insert({ user_id, name, project_ids: [] }, callback)
 
+	updateTagUserIds: (old_user_id, new_user_id, callback = (err, tag) ->) ->
+		searchOps =
+			user_id:old_user_id
+		updateOperation = 
+			"$set": {user_id:new_user_id}
+		db.tags.update(searchOps, updateOperation, multi:true, callback)
+
 	addProjectToTag: (user_id, tag_id, project_id, callback = (error) ->)->
 		try
 			tag_id = ObjectId(tag_id)
@@ -26,6 +33,14 @@ module.exports = Tags =
 		insertOperation = 
 			"$addToSet": {project_ids:project_id}
 		db.tags.update(searchOps, insertOperation, callback)
+
+	addProjectToTagName: (user_id, name, project_id, callback = (error) ->)->
+		searchOps =
+			name:name
+			user_id:user_id
+		insertOperation =
+			"$addToSet": {project_ids:project_id}
+		db.tags.update(searchOps, insertOperation, upsert:true, callback)
 
 	removeProjectFromTag: (user_id, tag_id, project_id, callback = (error) ->)->
 		try

--- a/app/coffee/TagsController.coffee
+++ b/app/coffee/TagsController.coffee
@@ -17,10 +17,26 @@ module.exports =
 			return next(error) if error?
 			res.json(tag)
 
+	updateTagUserIds: (req, res, next)->
+		old_user_id = req.params.user_id
+		new_user_id = req.body.user_id
+		logger.log {old_user_id, new_user_id}, "updating user_id for tags"
+		TagsRepository.updateTagUserIds old_user_id, new_user_id, (error)->
+			return next(error) if error?
+			res.status(204).end()
+
 	addProjectToTag: (req, res, next)->
 		{user_id, project_id, tag_id} = req.params
 		logger.log {user_id, project_id, tag_id}, "adding project to tag"
 		TagsRepository.addProjectToTag user_id, tag_id, project_id, (error) ->
+			return next(error) if error?
+			res.status(204).end()
+
+	addProjectToTagName: (req, res, next)->
+		{user_id, project_id} = req.params
+		name = req.body.name
+		logger.log {user_id, project_id, name}, "adding project to tag name"
+		TagsRepository.addProjectToTagName user_id, name, project_id, (error) ->
 			return next(error) if error?
 			res.status(204).end()
 

--- a/test/unit/coffee/TagsControllerTest.coffee
+++ b/test/unit/coffee/TagsControllerTest.coffee
@@ -55,6 +55,45 @@ describe 'Tags controller', ->
 			@res.status.calledWith(204).should.equal true
 			@res.end.called.should.equal true
 
+	describe "addProjectToTagName", ->
+		beforeEach ->
+			@tagsRepository.addProjectToTagName = sinon.stub().callsArg(3)
+			@req =
+				body:
+					name: tag_name
+				params:
+					user_id: user_id
+					project_id: project_id
+			@controller.addProjectToTagName @req, @res
+
+		it "should tell the repository to add the tag to the project", ->
+			@tagsRepository.addProjectToTagName
+				.calledWith(user_id, tag_name, project_id)
+				.should.equal true
+
+		it "should return a 204 status code", ->
+			@res.status.calledWith(204).should.equal true
+			@res.end.called.should.equal true
+
+	describe "updateTagUserIds", ->
+		beforeEach ->
+			@tagsRepository.updateTagUserIds = sinon.stub().callsArg(2)
+			@req =
+				body:
+					user_id: "new-user-id"
+				params:
+					user_id: "old-user-id"
+			@controller.updateTagUserIds @req, @res
+
+		it "should tell the repository to update user ids", ->
+			@tagsRepository.updateTagUserIds
+				.calledWith("old-user-id", "new-user-id")
+				.should.equal true
+
+		it "should return a 204 status code", ->
+			@res.status.calledWith(204).should.equal true
+			@res.end.called.should.equal true
+
 	describe "removeProjectFromTag", ->
 		beforeEach ->
 			@tagsRepository.removeProjectFromTag = sinon.stub().callsArg(3)

--- a/test/unit/coffee/TagsRepositoryTests.coffee
+++ b/test/unit/coffee/TagsRepositoryTests.coffee
@@ -77,6 +77,49 @@ describe 'TagsRepository', ->
 			it "should call the callback with and error", ->
 				@callback.calledWith(new Error()).should.equal true
 
+	describe 'addProjectToTagName', ->
+		beforeEach ->
+			@updateStub.callsArg(3)
+			@repository.addProjectToTagName user_id, tag_name, project_id, @callback
+
+		it "should call update in mongo", ->
+			expect(@updateStub.lastCall.args.slice(0,3)).to.deep.equal [
+				{
+					name: tag_name
+					user_id: user_id
+				},
+				{
+					$addToSet: { project_ids: project_id }
+				},
+				{
+					upsert: true
+				}
+			]
+
+		it "should call the callback", ->
+			@callback.called.should.equal true
+
+	describe 'updateTagUserIds', ->
+		beforeEach ->
+			@updateStub.callsArg(3)
+			@repository.updateTagUserIds "old-user-id", "new-user-id", @callback
+
+		it "should call update in mongo", ->
+			expect(@updateStub.lastCall.args.slice(0,3)).to.deep.equal [
+				{
+					user_id: "old-user-id"
+				},
+				{
+					$set: { user_id: "new-user-id" }
+				},
+				{
+					multi: true
+				}
+			]
+
+		it "should call the callback", ->
+			@callback.called.should.equal true
+
 	describe 'removeProjectFromTag', ->
 		describe "with a valid tag_id", ->
 			beforeEach ->


### PR DESCRIPTION
### Description

Add an API that allows projects to be tagged (added to a tag collection) by tag name instead of tag id.

This simplifies the implementation of clients by removing the need for clients to get the user's tags in advance and create tags that don't exist.

#### Screenshots

N/A

#### Related Issues / PRs

Closes overleaf/sharelatex/issues/805

### Review



#### Potential Impact

Low. Adds new API to internal service.

#### Manual Testing Performed

- POST N.N.N.N:3012/user/NNN/tag/name/XXX/project/XXX
- Check tag created with upsert
- POST N.N.N.N:3012/user/NNN/tag/name/XXX/project/YYY
- Check project added to existing tag

#### Accessibility

N/A

### Deployment

N/A

#### Deployment Checklist

N/A

#### Metrics and Monitoring

N/A

#### Who Needs to Know?

N/A