### PR TITLE
avoid exception when tag is removed by another health check

### DIFF
--- a/app/coffee/HealthCheckController.coffee
+++ b/app/coffee/HealthCheckController.coffee
@@ -14,7 +14,7 @@ module.exports =
 	check : (callback)->
 		project_id = ObjectId()
 		user_id = ObjectId(settings.tags.healthCheck.user_id)
-		tagName = "smoke-test-tag"
+		tagName = "smoke-test-tag-#{Math.floor(Math.random() * 50)}" # use a random tag name to reduce conflicts
 		request.post {
 			url: buildUrl("/user/#{user_id}/tag"),
 			json:

--- a/app/coffee/HealthCheckController.coffee
+++ b/app/coffee/HealthCheckController.coffee
@@ -25,6 +25,8 @@ module.exports =
 				return callback(err)
 			if res.statusCode != 200
 				return callback new Error("unexpected statusCode: #{res.statusCode}")
+			if !body?._id?
+				return callback new Error("#{tagName} tag not created - clobbered by another health check?")
 			logger.log {tag: body, user_id, project_id}, "health check created tag"
 			tag_id = body._id
 


### PR DESCRIPTION
I noticed the tags service in production is often restarting.  I had a look and found that it is crashing due to an exception in the health check when `body` is not defined:

https://github.com/sharelatex/tags-sharelatex/blob/131b558c1142436fdd3293b85774e76e726cf64c/app/coffee/HealthCheckController.coffee#L31

This happens when it creates a tag and at the same time another health check removes it between these two lines:

https://github.com/sharelatex/tags-sharelatex/blob/836012d9a258c76c40dc78c09c60fc2779f19b85/app/coffee/Repositories/Tags.coffee#L16-L19

I suggest we just handle the exception and fail the health check, it will likely pass the next time.
