### PR TITLE
remove old smoke tags

### DIFF
--- a/app/coffee/HealthCheckController.coffee
+++ b/app/coffee/HealthCheckController.coffee
@@ -65,10 +65,10 @@ module.exports = HealthCheck =
 						if err?
 							logger.log "Failed executing delete tags health check"
 						otherTags = (tag for tag in tags when tag._id isnt tag_id)
-						HealthCheck._removeOldTags otherTags, () ->
+						HealthCheck._removeOldTags user_id, otherTags, () ->
 							callback(err, res, body)
 
-	_removeOldTags: (tags, callback) ->
+	_removeOldTags: (user_id, tags, callback) ->
 		now = new Date()
 		getAge = (tag) ->
 			(now - ObjectId(tag._id).getTimestamp())

--- a/app/coffee/HealthCheckController.coffee
+++ b/app/coffee/HealthCheckController.coffee
@@ -10,7 +10,7 @@ request = request.defaults({timeout: 3000})
 buildUrl = (path) ->
 	"http://localhost:#{port}#{path}"
 
-module.exports =
+module.exports = HealthCheck = 
 	check : (callback)->
 		project_id = ObjectId()
 		user_id = ObjectId(settings.tags.healthCheck.user_id)
@@ -64,4 +64,20 @@ module.exports =
 					}, (err, res, body) ->
 						if err?
 							logger.log "Failed executing delete tags health check"
-						callback(err, res, body)
+						otherTags = (tag for tag in tags when tag._id isnt tag_id)
+						HealthCheck._removeOldTags otherTags, () ->
+							callback(err, res, body)
+
+	_removeOldTags: (tags, callback) ->
+		now = new Date()
+		getAge = (tag) ->
+			(now - ObjectId(tag._id).getTimestamp())
+		oldTags = (tag for tag in tags when getAge(tag) > 5*60*1000)
+		removeTag = (tag, cb) ->
+			logger.log {tag:tag}, "removing old tag"
+			request.del {
+				url: buildUrl("/user/#{user_id}/tag/#{tag._id}")
+				json: true
+			}, (err) ->
+				cb() # ignore failures removing old tags
+		async.mapSeries oldTags, removeTag, callback

--- a/app/coffee/HealthCheckController.coffee
+++ b/app/coffee/HealthCheckController.coffee
@@ -72,6 +72,7 @@ module.exports = HealthCheck =
 		now = new Date()
 		getAge = (tag) ->
 			(now - ObjectId(tag._id).getTimestamp())
+		# clean up tags older than 5 minutes
 		oldTags = (tag for tag in tags when getAge(tag) > 5*60*1000)
 		removeTag = (tag, cb) ->
 			logger.log {tag:tag}, "removing old tag"
@@ -80,4 +81,5 @@ module.exports = HealthCheck =
 				json: true
 			}, (err) ->
 				cb() # ignore failures removing old tags
-		async.mapSeries oldTags, removeTag, callback
+		# remove a limited number tags on each pass to avoid timeouts
+		async.mapSeries oldTags.slice(0,3), removeTag, callback


### PR DESCRIPTION
We have large numbers of old tags in the mongo collection from the smoke test.  This PR adds a cleanup method to each health check to remove the ones that are older than 5 minutes. Possibly we could just do it on startup.

